### PR TITLE
Inode Penetrate

### DIFF
--- a/cmd/enigma/fuse_darwin.go
+++ b/cmd/enigma/fuse_darwin.go
@@ -12,6 +12,8 @@ const (
 )
 
 func fuseFillWithStat(result *fuse.Attr, s *syscall.Stat_t) {
+	devMask := uint64(s.Dev)<<32 | uint64(s.Dev)>>32
+	result.Ino = devMask ^ s.Ino
 	result.Atime = uint64(s.Atimespec.Sec)
 	result.Atimensec = uint32(s.Atimespec.Nsec)
 	result.Mtime = uint64(s.Mtimespec.Sec)

--- a/cmd/enigma/fuse_linux.go
+++ b/cmd/enigma/fuse_linux.go
@@ -13,6 +13,8 @@ const (
 )
 
 func fuseFillWithStat(result *fuse.Attr, s *syscall.Stat_t) {
+	devMask := uint64(s.Dev)<<32 | uint64(s.Dev)>>32
+	result.Ino = devMask ^ s.Ino
 	result.Atime = uint64(s.Atim.Sec)
 	result.Atimensec = uint32(s.Atim.Nsec)
 	result.Mtime = uint64(s.Mtim.Sec)

--- a/cmd/enigma/fuse_unix.go
+++ b/cmd/enigma/fuse_unix.go
@@ -96,8 +96,6 @@ func fuseConvertFileMode(mode os.FileMode) uint32 {
 func fuseFillStat(fileInfo os.FileInfo) fuse.Attr {
 	var result fuse.Attr
 	result.Mode = fuseConvertFileMode(fileInfo.Mode())
-	result.Ino = 0
-	result.Rdev = 0
 	result.Size = uint64(fileInfo.Size())
 	modTime := fileInfo.ModTime()
 	if result.Atime == 0 && result.Atimensec == 0 {
@@ -138,6 +136,7 @@ func (n *fuseFileNode) Lookup(
 	}, fs.StableAttr{
 		Mode: out.Attr.Mode,
 		Gen:  1,
+		Ino:  out.Attr.Ino,
 	}), 0
 }
 
@@ -420,6 +419,7 @@ func (n *fuseFileNode) Create(
 	inode := n.NewInode(ctx, inner, fs.StableAttr{
 		Mode: out.Attr.Mode,
 		Gen:  1,
+		Ino:  out.Attr.Ino,
 	})
 	f = nil
 	return inode, result, fuse.FOPEN_DIRECT_IO, 0


### PR DESCRIPTION
1. Penetrate the underlying inode number for inode-dependent commands.